### PR TITLE
Fix - Added support for SVGs via imageDetails

### DIFF
--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react';
-import { UploadcareImage, UploadcareGif } from '../Uploadcare';
+
+import { UploadcareImage, UploadcareGif, UploadcareSvg } from '../Uploadcare';
 import { UploadcareImageProps } from '../../types';
 import getImageExtension from './lib/getImageExtension';
 
@@ -10,8 +11,9 @@ const Image: FunctionComponent<Props> = (props) => {
 
     // If it's a svg then there is no need for responsive image
     if (extension === 'svg') {
-        const { sizes, objectFit, layout, lazy, containerClassName, ...imgProps } = props;
-        return <img {...imgProps} loading={lazy ? 'lazy' : 'eager'} />;
+        return (
+            <UploadcareSvg {...props} />
+        );
     }
 
     // If it's a gif image then show it as a video, using Uploadcare's gif2video transformation

--- a/src/components/Uploadcare/Svg/UploadcareSvg.tsx
+++ b/src/components/Uploadcare/Svg/UploadcareSvg.tsx
@@ -1,0 +1,47 @@
+import React, { FunctionComponent } from 'react';
+
+import classNames from '../../../lib/classNames';
+import { UploadcareImageProps } from '../../../types';
+import { getPictureDetails } from '../Image/lib';
+
+const UploadcareSvg: FunctionComponent<UploadcareImageProps> = (props) => {
+    const {
+        className,
+        alt,
+        layout,
+        objectFit,
+        width,
+        height,
+        objectPosition,
+        lazy,
+    } = props;
+
+    const { image } = getPictureDetails(props);
+    const imageStyle =
+        layout === 'fixed'
+            ? undefined
+            : {
+                  objectFit,
+                  objectPosition,
+                  maxHeight: height,
+                  maxWidth: width,
+                  minHeight: height,
+                  minWidth: width,
+              };
+
+    return (
+        <img
+            className={classNames(
+                className,
+                'uploadcare-image__image',
+                layout === 'fill' && 'uploadcare-image__layout-fill',
+            )}
+            loading={lazy ? 'lazy' : 'eager'}
+            alt={alt}
+            style={imageStyle}
+            src={image.src}
+        />
+    );
+};
+
+export default UploadcareSvg;

--- a/src/components/Uploadcare/Svg/index.ts
+++ b/src/components/Uploadcare/Svg/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UploadcareSvg';

--- a/src/components/Uploadcare/index.ts
+++ b/src/components/Uploadcare/index.ts
@@ -1,4 +1,5 @@
 export { default as UploadcareImage } from './Image';
 export { default as UploadcareGif } from './Gif';
+export { default as UploadcareSvg } from './Svg';
 export { Breakpoint } from './constants';
 export { effects } from './lib';


### PR DESCRIPTION
This package was lacking support for `imageDetails` prop for SVG files from Uploadcare and because it was using object spreading, the `imageDetails` prop was just added into the final HTML instead of being processed first resulting in missing `src` attribute.

This PR adds support for this use case. The code is nearly identical to `UploadcareImage` component except that we don't care about various image sources because of the nature of SVG.